### PR TITLE
Removal of MacOS directory

### DIFF
--- a/lua/language-servers/init.lua
+++ b/lua/language-servers/init.lua
@@ -41,7 +41,7 @@ local sumneko_binary = ""
 
 if vim.fn.has("mac") == 1 then
   sumneko_root_path = "/Users/" .. USER .. "/.config/nvim/ls/lua-language-server"
-  sumneko_binary = "/Users/" .. USER .. "/.config/nvim/ls/lua-language-server/bin/macOS/lua-language-server"
+  sumneko_binary = "/Users/" .. USER .. "/.config/nvim/ls/lua-language-server/bin/lua-language-server"
 elseif vim.fn.has("unix") == 1 then
   sumneko_root_path = "/home/" .. USER .. "/.config/nvim/ls/lua-language-server"
   sumneko_binary = "/home/" .. USER .. "/.config/nvim/ls/lua-language-server/bin/Linux/lua-language-server"


### PR DESCRIPTION
Following the instructions of Readme, The MacOS directory is not generated in language server installation.