### PR TITLE
Adding `nvim-treesitter-endwise` as an configurable, built-in option …

### DIFF
--- a/lua/treesitter-config/init.lua
+++ b/lua/treesitter-config/init.lua
@@ -8,5 +8,6 @@ Vapour.utils.plugins.require'nvim-treesitter.configs'.setup {
   indent = Vapour.plugins.treesitter.indent,
   highlight = Vapour.plugins.treesitter.highlight,
   autotag = Vapour.plugins.treesitter.autotag,
+  endwise = Vapour.plugins.treesitter.endwise,
   rainbow = Vapour.plugins.treesitter.rainbow
 }

--- a/lua/vapour/init.lua
+++ b/lua/vapour/init.lua
@@ -77,6 +77,7 @@ Vapour = {
       indent = {enable = false},
       highlight = {enable = true},
       autotag = {enable = true},
+      endwise = {enable = true},
       rainbow = {enable = true, extended_mode = false, disable = {"html"}}
     },
     vsnip = {enabled = true},

--- a/lua/vapour/plugins/init.lua
+++ b/lua/vapour/plugins/init.lua
@@ -82,6 +82,7 @@ return packer.startup(function(use)
   }
   use {'p00f/nvim-ts-rainbow', disable = not is_enabled('treesitter'), after = 'nvim-treesitter'}
   use {'windwp/nvim-ts-autotag', disable = not is_enabled('treesitter'), after = 'nvim-treesitter'}
+  use {'RRethy/nvim-treesitter-endwise', disable = not is_enabled('treesitter'), after = 'nvim-treesitter'}
 
   -- Colorschemes
   use {'rose-pine/neovim', as = 'rose-pine', opt = true}


### PR DESCRIPTION
…with treesitter.

Followed the configuration pattern established with `autotag` and `rainbow`