### PR TITLE
Adding treesitter-textsubjects

### DIFF
--- a/lua/treesitter-config/init.lua
+++ b/lua/treesitter-config/init.lua
@@ -9,5 +9,6 @@ Vapour.utils.plugins.require'nvim-treesitter.configs'.setup {
   highlight = Vapour.plugins.treesitter.highlight,
   autotag = Vapour.plugins.treesitter.autotag,
   endwise = Vapour.plugins.treesitter.endwise,
-  rainbow = Vapour.plugins.treesitter.rainbow
+  rainbow = Vapour.plugins.treesitter.rainbow,
+  textsubjects = Vapour.plugins.treesitter.textsubjects
 }

--- a/lua/vapour/init.lua
+++ b/lua/vapour/init.lua
@@ -78,7 +78,16 @@ Vapour = {
       highlight = {enable = true},
       autotag = {enable = true},
       endwise = {enable = true},
-      rainbow = {enable = true, extended_mode = false, disable = {"html"}}
+      rainbow = {enable = true, extended_mode = false, disable = {"html"}},
+      textsubjects = {
+        enable = true,
+        prev_selection = ',', -- (Optional) keymap to select the previous selection
+        keymaps = {
+          ['.'] = 'textsubjects-smart',
+          [';'] = 'textsubjects-container-outer',
+          ['i;'] = 'textsubjects-container-inner',
+        },
+      },
     },
     vsnip = {enabled = true},
     telescope = {enabled = true},

--- a/lua/vapour/plugins/init.lua
+++ b/lua/vapour/plugins/init.lua
@@ -83,6 +83,7 @@ return packer.startup(function(use)
   use {'p00f/nvim-ts-rainbow', disable = not is_enabled('treesitter'), after = 'nvim-treesitter'}
   use {'windwp/nvim-ts-autotag', disable = not is_enabled('treesitter'), after = 'nvim-treesitter'}
   use {'RRethy/nvim-treesitter-endwise', disable = not is_enabled('treesitter'), after = 'nvim-treesitter'}
+  use {'RRethy/nvim-treesitter-textsubjects', disable = not is_enabled('treesitter'), after = 'nvim-treesitter'}
 
   -- Colorschemes
   use {'rose-pine/neovim', as = 'rose-pine', opt = true}


### PR DESCRIPTION
Adding [treesitter-textsubjects](https://github.com/RRethy/nvim-treesitter-textsubjects) as a configurable option to treesitter.  

This option is a helpful function that enables incremental visual selection, block-by-block.  
It behaves better than `vim-expand` for languages with `begin/do end` blocks like `Lua` and` Ruby`.  

Type `v`, then `.` repeatedly to `expand the selection`, or `;` repeatedly to `shrink the selection`.