### PR TITLE
`nvim_tree_ignore` moved to `filters.custom`

### DIFF
--- a/lua/nvimtree-config/init.lua
+++ b/lua/nvimtree-config/init.lua
@@ -1,7 +1,9 @@
-vim.g.nvim_tree_ignore = {'*.tmp', '.git'}
 vim.g.nvim_tree_indent_markers = 1
 local nvimtree = Vapour.utils.plugins.require 'nvim-tree'
 nvimtree.setup {
+  filters = {
+    custom = {'*.tmp', '.git'}
+  },
   disable_netrw = true,
   hijack_netrw = true,
   open_on_setup = true,


### PR DESCRIPTION
Based on a warning message as a result of [nvim-tree#674](https://github.com/kyazdani42/nvim-tree.lua/issues/674):

* The config variable `nvim_tree_ignore` has moved the setup
  configuration table `filters.custom`

This fix updates VapourNvim's default configuration in accordance with that move.