### PR TITLE
Update `toggleterm` to read from the branch `main`, as `master` is now gone.

### DIFF
--- a/lua/vapour/plugins/init.lua
+++ b/lua/vapour/plugins/init.lua
@@ -138,7 +138,8 @@ return packer.startup(function(use)
   use {
     'akinsho/nvim-toggleterm.lua',
     disable = not is_enabled('toggleterm'),
-    config = 'require"toggleterm-config"'
+    config = 'require"toggleterm-config"',
+    branch = 'main'
   }
 
   -- Navigation


### PR DESCRIPTION
For the plugin `toggleterm`, the source branch is no longer `master`; it is now `main`.  
`PackerSync` is not working unless we explicitly specify the branch is `main`.